### PR TITLE
Fix image memory leaks in native code

### DIFF
--- a/ui/image_fltk.go
+++ b/ui/image_fltk.go
@@ -9,7 +9,14 @@ import (
 	"github.com/roblillack/spot"
 )
 
-type nativeTypeImage = *goFltk.Box
+// There's currently no way to get the current RgbImage out of the
+// box, so we have to keep a reference to it.
+type fltkImageWrapper struct {
+	box *goFltk.Box
+	img *goFltk.RgbImage
+}
+
+type nativeTypeImage = *fltkImageWrapper
 
 func (c *Image) Update(nextControl spot.Control) bool {
 	next, ok := nextControl.(*Image)
@@ -37,12 +44,15 @@ func (c *Image) Mount(parent spot.Control) any {
 		return nil
 	}
 
-	c.ref = goFltk.NewBox(goFltk.DOWN_BOX, c.X, c.Y, c.Width, c.Height)
-	c.ref.SetEventHandler(c.handleEvent)
+	box := goFltk.NewBox(goFltk.DOWN_BOX, c.X, c.Y, c.Width, c.Height)
+	box.SetEventHandler(c.handleEvent)
+	c.ref = &fltkImageWrapper{
+		box: box,
+	}
 	c.draw()
 
 	if window, ok := parent.(*Window); ok && window != nil && window.ref != nil {
-		window.ref.Add(c.ref)
+		window.ref.Add(box)
 	}
 
 	return c.ref
@@ -53,7 +63,14 @@ func (b *Image) Unmount() {
 		return
 	}
 
-	b.ref.Destroy()
+	if b.ref.img != nil {
+		b.ref.img.Destroy()
+	}
+
+	if b.ref.box != nil {
+		b.ref.box.Destroy()
+	}
+
 	b.ref = nil
 }
 
@@ -84,6 +101,11 @@ func (c *Image) draw() {
 		log.Println(err)
 		return
 	}
-	c.ref.SetImage(fimg)
-	c.ref.Redraw()
+	oldImg := c.ref.img
+	c.ref.img = fimg
+	c.ref.box.SetImage(fimg)
+	c.ref.box.Redraw()
+	if oldImg != nil {
+		oldImg.Destroy()
+	}
 }

--- a/ui/internal/cocoa/image.m
+++ b/ui/internal/cocoa/image.m
@@ -2,7 +2,7 @@
 #include "_cgo_export.h"
 
 ImagePtr Image_NewWithRGBA(int w, int h, unsigned char *rgba) {
-  NSBitmapImageRep *bitmap = [[NSBitmapImageRep alloc]
+  NSBitmapImageRep *bitmap = [[[NSBitmapImageRep alloc]
       initWithBitmapDataPlanes:NULL
                     pixelsWide:w
                     pixelsHigh:h
@@ -12,12 +12,12 @@ ImagePtr Image_NewWithRGBA(int w, int h, unsigned char *rgba) {
                       isPlanar:NO
                 colorSpaceName:NSCalibratedRGBColorSpace
                    bytesPerRow:w * 4
-                  bitsPerPixel:32];
+                  bitsPerPixel:32] autorelease];
 
   unsigned char *bitmapData = [bitmap bitmapData];
   memcpy(bitmapData, rgba, w * h * 4);
 
-  NSImage *theImage = [[NSImage alloc] init];
+  NSImage *theImage = [[[NSImage alloc] init] autorelease];
   [theImage addRepresentation:bitmap];
 
   return (ImagePtr)theImage;


### PR DESCRIPTION
This PR fixes a memory leak when updating a `ui.Image`'s content. Weirdly enough, the very same memory leak existed in native code for the Cocoa _and_ the FLTK backend. For Cocoa, we can fix it directly, for FLTK we cannot easily, as currently, there's no way to read the reference to a `goFltk.RgbImage` from a `goFltk.Box`, so the native implementation will be a wrapper about a Box _and_ Image, in order for us to keep a reference to the image we might want to `Destroy()` after replacing it.

Ticket: #30 